### PR TITLE
Feature/tvmaze models

### DIFF
--- a/MyShow.Data/Entities/TvShow.cs
+++ b/MyShow.Data/Entities/TvShow.cs
@@ -4,7 +4,7 @@ public class TvShow
 {
     public int Id { get; set; }
     public string Name { get; set; }
-    public string ImageUrl { get; set; }
+    public string ImageUri { get; set; }
     public ICollection<Episode> Episodes { get; set; }
     public int ApiId { get; set; }
 }

--- a/MyShow.Data/Services/Maze/MazeEmbedded.cs
+++ b/MyShow.Data/Services/Maze/MazeEmbedded.cs
@@ -1,0 +1,6 @@
+﻿namespace MyShow.Data.Services.Maze;
+
+public class MazeEmbedded
+{
+    public MazeNextEpisode NextEpisode { get; set; }
+}

--- a/MyShow.Data/Services/Maze/MazeEmbedded.cs
+++ b/MyShow.Data/Services/Maze/MazeEmbedded.cs
@@ -2,5 +2,5 @@
 
 public class MazeEmbedded
 {
-    public MazeNextEpisode NextEpisode { get; set; }
+    public MazeEpisode NextEpisode { get; set; }
 }

--- a/MyShow.Data/Services/Maze/MazeEpisode.cs
+++ b/MyShow.Data/Services/Maze/MazeEpisode.cs
@@ -2,7 +2,7 @@
 
 namespace MyShow.Data.Services.Maze;
 
-public class MazeNextEpisode
+public class MazeEpisode
 {
     public int Id { get; set; }
     public string Name { get; set; }

--- a/MyShow.Data/Services/Maze/MazeImage.cs
+++ b/MyShow.Data/Services/Maze/MazeImage.cs
@@ -1,0 +1,9 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MyShow.Data.Services.Maze;
+
+public class MazeImage
+{
+    [JsonPropertyName("medium")]
+    public string Uri { get; set; }
+}

--- a/MyShow.Data/Services/Maze/MazeNextepisode.cs
+++ b/MyShow.Data/Services/Maze/MazeNextepisode.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MyShow.Data.Services.Maze;
+
+public class MazeNextEpisode
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public int Season { get; set; }
+    public int Number { get; set; }
+
+    [JsonPropertyName("airstamp")]
+    public DateTime AirDate { get; set; }
+}

--- a/MyShow.Data/Services/Maze/MazeTvShow.cs
+++ b/MyShow.Data/Services/Maze/MazeTvShow.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MyShow.Data.Services.Maze;
+
+public class MazeTvShow
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Status { get; set; }
+    public MazeImage Image { get; set; }
+
+    [JsonPropertyName("_embedded")]
+    public MazeEmbedded Embedded { get; set; }
+}

--- a/MyShow.Data/Services/Maze/MazeTvShow.cs
+++ b/MyShow.Data/Services/Maze/MazeTvShow.cs
@@ -4,7 +4,9 @@ namespace MyShow.Data.Services.Maze;
 
 public class MazeTvShow
 {
-    public int Id { get; set; }
+    [JsonPropertyName("id")]
+    public int ApiId { get; set; }
+
     public string Name { get; set; }
     public string Status { get; set; }
     public MazeImage Image { get; set; }

--- a/MyShow.Data/Services/Maze/MazeTvShowService.cs
+++ b/MyShow.Data/Services/Maze/MazeTvShowService.cs
@@ -1,6 +1,6 @@
 ﻿using MyShow.Data.Services.Interfaces;
 
-namespace MyShow.Data.Services;
+namespace MyShow.Data.Services.Maze;
 
 public class MazeTvShowService : ITvShowService
 {
@@ -23,7 +23,7 @@ public class MazeTvShowService : ITvShowService
 
         var response = await _httpClient.GetAsync(uriBuilder.Uri);
 
-        if (response is null) 
+        if (response is null)
             return null;
 
         var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/MyShow.MVC/Program.cs
+++ b/MyShow.MVC/Program.cs
@@ -1,13 +1,13 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using MyShow.Core.Extensions;
-using MyShow.Data.Services;
 using MyShow.Data.Services.Interfaces;
 using MyShow.Data;
 using MyShow.Data.Extensions;
 using MyShow.MVC.Policies;
 using System.Net.Http.Headers;
 using static System.Net.Mime.MediaTypeNames;
+using MyShow.Data.Services.Maze;
 
 var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
closes #6 
Uri is the full path to the resource meanwhile Url is just a part of it so changed that, it will also allow us to use automappers by convention approach - meaning we don't have to configure the mapping from the MazeTvShow class's `Image.Uri` property to our `ImageUri` property in the TvShow Entity.


```
public class TvShow
{
// auto mapper auto gets the Uri value from the Image object because of the naming convention we followed
// We used ImageUri which is the Image property inside MazeTvShow and then it's property Uri.
    public string ImageUri { get; set; } 
}

public class MazeTvShow
{
    public Image Image { get; set; }
}

public class Image
{
    public string Uri{ get; set; }
}
```
